### PR TITLE
戻り値の`OCWCourse`の開講年を`courseId`から取得

### DIFF
--- a/Sources/TitechOCWKit/Paser/OCWHTMLPaser.swift
+++ b/Sources/TitechOCWKit/Paser/OCWHTMLPaser.swift
@@ -13,7 +13,7 @@ enum OCWHTMLPaser {
         let doc: Document = try SwiftSoup.parse(html)
         
         let courseYearString = courseId.prefix(4)
-        let courseYear = Int(courseYearString)!
+        let courseYear = Int(courseYearString) ?? -1
         
         let titleString = try doc
             .select("div.page-title-area h3")

--- a/Sources/TitechOCWKit/Paser/OCWHTMLPaser.swift
+++ b/Sources/TitechOCWKit/Paser/OCWHTMLPaser.swift
@@ -9,9 +9,12 @@ import Foundation
 import SwiftSoup
 
 enum OCWHTMLPaser {
-    static func parse(html: String) throws -> OCWCourse {
+    static func parse(html: String, courseId: String) throws -> OCWCourse {
         let doc: Document = try SwiftSoup.parse(html)
-
+        
+        let courseYearString = courseId.prefix(4)
+        let courseYear = Int(courseYearString)!
+        
         let titleString = try doc
             .select("div.page-title-area h3")
             .html()
@@ -70,7 +73,7 @@ enum OCWHTMLPaser {
             nameEn: titleArr[0][1],
             periods: periods,
             terms: quarters.map {
-                OCWCourseTerm(year: 2023, quarter: $0)
+                OCWCourseTerm(year: courseYear, quarter: $0)
             }
         )
     }

--- a/Sources/TitechOCWKit/Paser/OCWHTMLPaser.swift
+++ b/Sources/TitechOCWKit/Paser/OCWHTMLPaser.swift
@@ -70,7 +70,7 @@ enum OCWHTMLPaser {
             nameEn: titleArr[0][1],
             periods: periods,
             terms: quarters.map {
-                OCWCourseTerm(year: 2022, quarter: $0)
+                OCWCourseTerm(year: 2023, quarter: $0)
             }
         )
     }

--- a/Sources/TitechOCWKit/TitechOCWKit.swift
+++ b/Sources/TitechOCWKit/TitechOCWKit.swift
@@ -37,7 +37,7 @@ public struct TitechOCW {
             let byteBuffer = try await response.body.collect(upTo: .max)
             let data = byteBuffer.getData(at: 0, length: byteBuffer.readableBytes)
             let html = String(data: data ?? Data(), encoding: .utf8) ?? ""
-            return try OCWHTMLPaser.parse(html: html)
+            return try OCWHTMLPaser.parse(html: html, courseId: courseId)
         } else {
             throw TitechOCWError.invalidHTTPStatusCode(code: response.status.code)
         }

--- a/Tests/TitechOCWKitTests/OCWHTMLPaserTests.swift
+++ b/Tests/TitechOCWKitTests/OCWHTMLPaserTests.swift
@@ -12,7 +12,7 @@ final class OCWHTMLPaserTests: XCTestCase {
 
     func testParseFor202201977() throws {
         let html = try! String(contentsOf: Bundle.module.url(forResource: "202201977", withExtension: "html")!)
-        let course = try OCWHTMLPaser.parse(html: html)
+        let course = try OCWHTMLPaser.parse(html: html, courseId: "202201977")
         
         XCTAssertEqual(
             course,
@@ -32,7 +32,7 @@ final class OCWHTMLPaserTests: XCTestCase {
     
     func testParseFor202206894() throws {
         let html = try! String(contentsOf: Bundle.module.url(forResource: "202206894", withExtension: "html")!)
-        let course = try OCWHTMLPaser.parse(html: html)
+        let course = try OCWHTMLPaser.parse(html: html, courseId: "202206894")
         
         XCTAssertEqual(
             course,
@@ -52,7 +52,7 @@ final class OCWHTMLPaserTests: XCTestCase {
     
     func testParseFor202200304() throws {
         let html = try! String(contentsOf: Bundle.module.url(forResource: "202200304", withExtension: "html")!)
-        let course = try OCWHTMLPaser.parse(html: html)
+        let course = try OCWHTMLPaser.parse(html: html, courseId: "202200304")
         
         XCTAssertEqual(
             course,
@@ -72,7 +72,7 @@ final class OCWHTMLPaserTests: XCTestCase {
 
     func testParseFor202202559() throws {
         let html = try! String(contentsOf: Bundle.module.url(forResource: "202202559", withExtension: "html")!)
-        let course = try OCWHTMLPaser.parse(html: html)
+        let course = try OCWHTMLPaser.parse(html: html, courseId: "202202559")
         
         XCTAssertEqual(
             course,
@@ -92,7 +92,7 @@ final class OCWHTMLPaserTests: XCTestCase {
     
     func testParseFor202202207() throws {
         let html = try! String(contentsOf: Bundle.module.url(forResource: "202202207", withExtension: "html")!)
-        let course = try OCWHTMLPaser.parse(html: html)
+        let course = try OCWHTMLPaser.parse(html: html, courseId: "202202207")
         
         XCTAssertEqual(
             course,


### PR DESCRIPTION
講義の年が全て2022年になっていたので修正